### PR TITLE
Expand environment variables in properties for runner and ndproj

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
       <scope>test</scope>
       <version>1.9.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.19.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/sonar/plugins/ndepend/NDependConfiguration.java
+++ b/src/main/java/org/sonar/plugins/ndepend/NDependConfiguration.java
@@ -69,6 +69,9 @@ public class NDependConfiguration implements BatchExtension, ServerExtension {
   }
 
   private String expandEnvironmentVariables(final String path) {
+    if(path == null) {
+      return path;
+    }
     final Pattern p = Pattern.compile("\\$\\{env:(\\w+)\\}");
     final Matcher m = p.matcher(path);
     if(!m.matches()) {

--- a/src/test/java/org/sonar/plugins/ndepend/NDependConfigurationTest.java
+++ b/src/test/java/org/sonar/plugins/ndepend/NDependConfigurationTest.java
@@ -22,6 +22,7 @@ package org.sonar.plugins.ndepend;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.rules.ExpectedException;
 import org.sonar.api.config.Settings;
 
@@ -33,7 +34,8 @@ public class NDependConfigurationTest {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
-
+  @Rule
+  public EnvironmentVariables environmentVariables = new EnvironmentVariables();
   private Settings settings;
   private NDependConfiguration conf;
 
@@ -63,6 +65,40 @@ public class NDependConfigurationTest {
     File file = new File("src/test/resources/NDependConfigurationTest/file.txt");
     settings.setProperty(NDependPlugin.NDEPEND_PROJECT_PATH_PROPERTY_KEY, file.getAbsolutePath());
     assertThat(conf.ndependProjectPath()).isEqualTo(file.getAbsolutePath());
+  }
+
+  @Test
+  public void ndependProjectPath_IsEnvironmentVariable_ShouldBeExpanded() {
+    File file = new File("src/test/resources/NDependConfigurationTest/file.txt");
+    environmentVariables.set("ProjectPath", file.getAbsolutePath());
+    settings.setProperty(NDependPlugin.NDEPEND_PROJECT_PATH_PROPERTY_KEY, "${env:ProjectPath}");
+    assertThat(conf.ndependProjectPath()).isEqualTo(file.getAbsolutePath());
+  }
+
+  @Test
+  public void ndependProjectPath_IsEnvironmentVariableButNotSet_ShouldThrowException() {
+    settings.setProperty(NDependPlugin.NDEPEND_PROJECT_PATH_PROPERTY_KEY, "${env:ProjectPath}");
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("The path provided in the property \"" + NDependPlugin.NDEPEND_PROJECT_PATH_PROPERTY_KEY + "\" must be an absolute path: ${env:ProjectPath}");
+    conf.ndependProjectPath();
+  }
+
+  @Test
+  public void ndependRuleRunnerPath_IsEnvironmentVariable_ShouldBeExpanded() {
+    File file = new File("src/test/resources/NDependConfigurationTest/file.txt");
+    environmentVariables.set("RunnerPath", file.getAbsolutePath());
+    settings.setProperty(NDependPlugin.RULE_RUNNER_PATH_PROPERTY_KEY, "${env:RunnerPath}");
+    assertThat(conf.ruleRunnerPath()).isEqualTo(file.getAbsolutePath());
+  }
+
+  @Test
+  public void ndependRuleRunnerPath_IsEnvironmentVariableButNotSet_ShouldThrowException() {
+    settings.setProperty(NDependPlugin.RULE_RUNNER_PATH_PROPERTY_KEY, "${env:RunnerPath}");
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("The path provided in the property \"" + NDependPlugin.RULE_RUNNER_PATH_PROPERTY_KEY + "\" must be an absolute path: ${env:RunnerPath}");
+    conf.ruleRunnerPath();
   }
 
   @Test


### PR DESCRIPTION
Especially in VSTS environment using build variables is very helpful. If for example the NDepend VSTS extension is installed the rule runner now can be configured with ${env:DevopsNDependPath}. Or the to be used ndproj file can be used from the checked in sources with ${env:Build.SourceDirectory}/your/path/to.ndproj.